### PR TITLE
Clean out non-string option values before use

### DIFF
--- a/lib/pkgify.js
+++ b/lib/pkgify.js
@@ -7,6 +7,8 @@ var _ = require("lodash-node");
 var getPackageMap = _.once(function (relativeTo, pkgs) {
   relativeTo = path.resolve(relativeTo);
   log("Generating pkgify map relative to", relativeTo);
+  // Remove non-string values, like `_: []` from subarg
+  pkgs = _.pick(pkgs, _.isString);
   var map = _.map(pkgs, function (src, name) {
     var pkg = {
       name: name,


### PR DESCRIPTION
Required to let pkgify work as a commandline provided transform...
Fixes #6
