### PR TITLE
:bug: Fix package regex matching

### DIFF
--- a/lib/pkgify.js
+++ b/lib/pkgify.js
@@ -16,8 +16,10 @@ var getPackageMap = _.once(function (relativeTo, pkgs) {
       abs: path.resolve(relativeTo, src),
       dir: false
     };
+    var isPkgRegexp = "^" + pkg.name + "$";
+    var isWithinPkgRegexp = "^" + pkg.name + "/";
     pkg.depth = pkg.src.split("/").length;
-    pkg.regexp = new RegExp("^" + pkg.name);
+    pkg.regexp = new RegExp(isPkgRegexp + "|" + isWithinPkgRegexp);
     var stat = fs.statSync(pkg.abs);
     if (stat.isDirectory()) {
       pkg.dir = true;


### PR DESCRIPTION
Hello. I found an issue when trying to use packages with similar names and put together a quick fix for it. Let me know if this makes sense or if you have any changes.

---

Fix an issue where similarly named packages collide.
For example, imagine this `pkgify` config:

``` json
"pkgify": {
  "packages": {
    "some-package": "path/to/some-package"
  }
}
```

And then you also install `some-package-plugin` in your
`dependencies`. When a `require` statement for `some-package-plugin`
goes through `pkgify`, it currently matches `some-package` which
is undesirable since `some-package` and `some-package-plugin` are
completely different packages. To work around this, test whether
the `some-package` is `require`d directly via `^...$` _or_ if something
_within_ `some-package` is `require`d via `^.../`, ie
`some-package/something-in-it`.
